### PR TITLE
:bookmark: bump version 0.1.0 -> 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ Source = "https://github.com/westerveltco/django-simple-nav"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.1.0"
+current_version = "0.2.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_simple_nav/__init__.py
+++ b/src/django_simple_nav/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __template_version__ = "2024.10"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_simple_nav import __version__
 
 
 def test_version():
-    assert __version__ == "0.1.0"
+    assert __version__ == "0.2.0"


### PR DESCRIPTION
- `f698ca8`: Update CHANGELOG.md
- `88293b7`: update repo using `django-twc-package` template (#17)
- `83a8a3f`: bump template to 2024.5 (#18)
- `70054ea`: bump template to 2024.8 (#19)
- `5cd2a87`: bump template to 2024.10 (#21)
- `30a2cea`: [pre-commit.ci] pre-commit autoupdate (#20)
- `f0b15eb`: remove `.copier-answers` directory (#25)
- `32a1776`: move `count_anchors` from fixture to test util (#26)
- `64d9518`: bump dev status to beta (#28)
- `4996e26`: add tests for `django_simple_nav.permissions` (#27)
- `625a7eb`: allow for passing an `Nav` instance to templatetag (#13)