### PR TITLE
:bookmark: bump version 0.5.1 -> 0.6.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.16
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.5.1
+current_version: 0.6.0
 django_versions:
 - '3.2'
 - '4.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.6.0]
+
 ### Added
 
 -   Added two new methods to `Nav`: `get_items` and `get_template_name`. These should allow for further flexibility and customization of rendering the `Nav`.
@@ -111,10 +113,11 @@ Initial release! 🎉
 -   Josh Thomas <josh@joshthomas.dev> (maintainer)
 -   Jeff Triplett [@jefftriplett](https://github.com/jefftriplett)
 
-[unreleased]: https://github.com/westerveltco/django-simple-nav/compare/v0.5.1...HEAD
+[unreleased]: https://github.com/westerveltco/django-simple-nav/compare/v0.6.0...HEAD
 [0.1.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.1.0
 [0.2.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.2.0
 [0.3.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.3.0
 [0.4.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.4.0
 [0.5.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.5.0
 [0.5.1]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.5.1
+[0.6.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ Source = "https://github.com/westerveltco/django-simple-nav"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.5.1"
+current_version = "0.6.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_simple_nav/__init__.py
+++ b/src/django_simple_nav/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 __template_version__ = "2024.16"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_simple_nav import __version__
 
 
 def test_version():
-    assert __version__ == "0.5.1"
+    assert __version__ == "0.6.0"


### PR DESCRIPTION
- `68ed712`: change release to `uv`
- `9a91582`: :robot: [pre-commit.ci] pre-commit autoupdate (#61)
- `147a2f8`: bump template to v2024.16 (#64)
- `fd880d9`: :robot: [pre-commit.ci] pre-commit autoupdate (#65)
- `117d415`: add `get_template_name` and `get_items` methods to `Nav` (#69)
- `965906c`: fix active nav item matching (#71)
- `05d449e`: [pre-commit.ci] pre-commit autoupdate (#66)
- `95cc4ba`: add ability to pass in args to `pytest` in `nox` session (#72)