### PR TITLE
:bookmark: bump version 0.6.0 -> 0.7.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.20
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.6.0
+current_version: 0.7.0
 django_versions:
 - '4.2'
 - '5.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.7.0]
+
 ### Added
 
 - `NavItem` and `NavGroup` now both have a `get_context_data` that returns the context needed for template rendering.
@@ -143,7 +145,7 @@ Initial release! 🎉
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 - Jeff Triplett [@jefftriplett](https://github.com/jefftriplett)
 
-[unreleased]: https://github.com/westerveltco/django-simple-nav/compare/v0.6.0...HEAD
+[unreleased]: https://github.com/westerveltco/django-simple-nav/compare/v0.7.0...HEAD
 [0.1.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.1.0
 [0.2.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.2.0
 [0.3.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.3.0
@@ -151,3 +153,4 @@ Initial release! 🎉
 [0.5.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.5.0
 [0.5.1]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.5.1
 [0.6.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.6.0
+[0.7.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ stubPath = "src/stubs"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.6.0"
+current_version = "0.7.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_simple_nav/__init__.py
+++ b/src/django_simple_nav/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_simple_nav import __version__
 
 
 def test_version():
-    assert __version__ == "0.6.0"
+    assert __version__ == "0.7.0"


### PR DESCRIPTION
- `6ad22a3`: move `request.user` check to earlier in `check_item_permissions` (#76)
- `8688bfe`: [pre-commit.ci] pre-commit autoupdate (#77)
- `259960b`: [pre-commit.ci] pre-commit autoupdate (#78)
- `39b5446`: [pre-commit.ci] pre-commit autoupdate (#80)
- `4c0dfd5`: [pre-commit.ci] pre-commit autoupdate (#81)
- `51448e5`: [pre-commit.ci] pre-commit autoupdate (#82)
- `0cb685a`: [pre-commit.ci] pre-commit autoupdate (#83)
- `6e1b22d`: :robot: :arrow_up: [pre-commit.ci] pre-commit autoupdate (#84)
- `4a25119`: [pre-commit.ci] pre-commit autoupdate (#85)
- `fd66680`: [pre-commit.ci] pre-commit autoupdate (#86)
- `0635f94`: [pre-commit.ci] pre-commit autoupdate (#87)
- `886694b`: add basedpyright config and convert `Any` to `object` hints (#88)
- `2b1395e`: simplify `Nav` rendering (#89)
- `ac8fa1e`: bump template to v2024.20 and drop support for Django 3.2 (#91)
- `d0e1d46`: add ability for permission to be a callable (#92)
- `454382c`: Update README to include required setting changes (#94)
- `6b4fc49`: [pre-commit.ci] pre-commit autoupdate (#93)
- `40bfa91`: refactor templatetag and add type hints (#95)
- `a0ba659`: add `get_template` to `Nav` (#96)
- `8b15fa0`: update changelog
- `a2e95fc`: rearrange `Nav` methods
- `5dacba1`: clean up some formatting, layout, and exception messages
- `cdf5fc2`: remove `request` from `get_context_data` return
- `3178641`: adjust README requirements to updated needs
- `2a4daa7`: fix active url detection (#98)
- `39a832c`: add ruff to dev extras
- `1b3ef70`: fix permission checks for multiple perms and `NavGroup` (#99)
- `35f7ba0`: refactor and shore up test suite (#100)
- `fd89f2d`: refactor `get_context_data` (#103)
- `614da32`: update changelog for permissions check
- `7ce51e3`: add `NavItem.get_items` (#104)
- `541317a`: `NavGroup` now marked as active if any item URLs are active (#105)
- `4c5c350`: add `_templates.get_template_engine` tests (#106)
- `18ddc5c`: add tests for `django_simple_nav` templatetag to round out coverage (#107)
- `73164b0`: remove typing extensions import from coverage