### PR TITLE
:bookmark: bump version 0.8.0 -> 0.9.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.20
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.8.0
+current_version: 0.9.0
 django_versions:
 - '4.2'
 - '5.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.9.0]
+
 ### Changed
 
 - Updated `NavItem.get_active` to allow for using URLs that contain query strings.
@@ -155,7 +157,7 @@ Initial release! 🎉
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 - Jeff Triplett [@jefftriplett](https://github.com/jefftriplett)
 
-[unreleased]: https://github.com/westerveltco/django-simple-nav/compare/v0.8.0...HEAD
+[unreleased]: https://github.com/westerveltco/django-simple-nav/compare/v0.9.0...HEAD
 [0.1.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.1.0
 [0.2.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.2.0
 [0.3.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.3.0
@@ -165,3 +167,4 @@ Initial release! 🎉
 [0.6.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.6.0
 [0.7.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.7.0
 [0.8.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.8.0
+[0.9.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ stubPath = "src/stubs"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.8.0"
+current_version = "0.9.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_simple_nav/__init__.py
+++ b/src/django_simple_nav/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_simple_nav import __version__
 
 
 def test_version():
-    assert __version__ == "0.8.0"
+    assert __version__ == "0.9.0"


### PR DESCRIPTION
- `85433f8`: fix active `NavItem` check for urls with query params (#114)