### PR TITLE
🔖 bump version 0.9.0 -> 0.10.0 (2nd try)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ stubPath = "src/stubs"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.10.0"
+current_version = "0.9.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_simple_nav/__init__.py
+++ b/src/django_simple_nav/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.10.0"
+__version__ = "0.9.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_simple_nav import __version__
 
 
 def test_version():
-    assert __version__ == "0.10.0"
+    assert __version__ == "0.9.0"


### PR DESCRIPTION
- `fbf94e8`: [pre-commit.ci] pre-commit autoupdate (#116)
- `c879c10`: bump template to 2024.23 (#117)
- `3678860`: :bookmark: bump version 0.9.0 -> 0.10.0 (#118)
- `f8823c3`: allow for calling test workflow