### PR TITLE
:bookmark: bump version 0.11.0 -> 0.12.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.29
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.11.0
+current_version: 0.12.0
 django_versions:
 - '4.2'
 - '5.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.12.0]
+
 ### Changed
 
 - Bumped `django-twc-package` template to v2024.29.
@@ -183,7 +185,7 @@ Initial release! 🎉
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 - Jeff Triplett [@jefftriplett](https://github.com/jefftriplett)
 
-[unreleased]: https://github.com/westerveltco/django-simple-nav/compare/v0.11.0...HEAD
+[unreleased]: https://github.com/westerveltco/django-simple-nav/compare/v0.12.0...HEAD
 [0.1.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.1.0
 [0.2.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.2.0
 [0.3.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.3.0
@@ -196,3 +198,4 @@ Initial release! 🎉
 [0.9.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.9.0
 [0.10.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.10.0
 [0.11.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.11.0
+[0.12.0]: https://github.com/westerveltco/django-simple-nav/releases/tag/v0.12.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ include = ["src"]
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.11.0"
+current_version = "0.12.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_simple_nav/__init__.py
+++ b/src/django_simple_nav/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_simple_nav import __version__
 
 
 def test_version():
-    assert __version__ == "0.11.0"
+    assert __version__ == "0.12.0"


### PR DESCRIPTION
- `9101466`: [pre-commit.ci] pre-commit autoupdate (#128)
- `5979fa0`: :robot: [pre-commit.ci] pre-commit autoupdate (#129)
- `f043992`: bump template to v2024.27 and add support for Django 5.1
- `edd7187`: add exceptions for Python versions and Django 5.1 (#131)
- `7679924`: [pre-commit.ci] pre-commit autoupdate (#130)
- `ae7e94e`: use nox to generate github job matrix for tests (#133)
- `b7d8e0e`: [pre-commit.ci] pre-commit autoupdate (#134)
- `4b3c687`: move to using nox and uv (#135)
- `0ae72c8`: bump template to v2024.29 (#136)
- `956bb71`: set python version in nox sessions when syncing uv (#138)
- `9a8f1eb`: [pre-commit.ci] pre-commit autoupdate (#139)
- `9765d95`: [pre-commit.ci] pre-commit autoupdate (#140)
- `06c75cc`: [pre-commit.ci] pre-commit autoupdate (#141)
- `ebc67e4`: [pre-commit.ci] pre-commit autoupdate (#143)
- `d8f0917`: [pre-commit.ci] pre-commit autoupdate (#144)
- `5b817db`: [pre-commit.ci] pre-commit autoupdate (#146)
- `d654610`: Bump astral-sh/setup-uv from 3 to 4 in the gha group (#145)
- `4ecea3e`: :robot: [pre-commit.ci] pre-commit autoupdate (#147)
- `92a22e9`: :robot: [pre-commit.ci] pre-commit autoupdate (#148)
- `2543f9b`: [pre-commit.ci] pre-commit autoupdate (#149)
- `a0c2f97`: :robot: Bump astral-sh/setup-uv from 4 to 5 in the gha group (#150)
- `59d017c`: [pre-commit.ci] pre-commit autoupdate (#151)
- `9fe88bd`: [pre-commit.ci] pre-commit autoupdate (#152)
- `042c607`: :robot: [pre-commit.ci] pre-commit autoupdate (#153)
- `213ac03`: [pre-commit.ci] pre-commit autoupdate (#154)
- `d1074c9`: bump min Python version for `main` Django and add 5.2a1 (#156)
- `47df601`: [pre-commit.ci] pre-commit autoupdate (#155)