### PR TITLE
Ignore missing URL parts in NavItem activity check

### DIFF
--- a/src/django_simple_nav/nav.py
+++ b/src/django_simple_nav/nav.py
@@ -140,10 +140,8 @@ class NavItem:
         parsed_url = urlparse(url)
         parsed_request = urlparse(request.build_absolute_uri())
 
-        if (
-            (parsed_url.scheme and (parsed_url.scheme != parsed_request.scheme))
-            or
-            (parsed_url.netloc and (parsed_url.netloc != parsed_request.netloc))
+        if (parsed_url.scheme and (parsed_url.scheme != parsed_request.scheme)) or (
+            parsed_url.netloc and (parsed_url.netloc != parsed_request.netloc)
         ):
             return False
 

--- a/src/django_simple_nav/nav.py
+++ b/src/django_simple_nav/nav.py
@@ -141,8 +141,9 @@ class NavItem:
         parsed_request = urlparse(request.build_absolute_uri())
 
         if (
-            parsed_url.scheme != parsed_request.scheme
-            or parsed_url.netloc != parsed_request.netloc
+            (parsed_url.scheme and (parsed_url.scheme != parsed_request.scheme))
+            or
+            (parsed_url.netloc and (parsed_url.netloc != parsed_request.netloc))
         ):
             return False
 

--- a/tests/test_navitem.py
+++ b/tests/test_navitem.py
@@ -156,6 +156,14 @@ def test_active_different_domain(rf):
     assert item.get_active(req) is False
 
 
+def test_active_no_scheme_no_netloc(rf):
+    item = NavItem(title=..., url="/test/")
+
+    req = rf.get("/test")
+
+    assert item.get_active(req) is True
+
+
 @pytest.mark.parametrize("append_slash", [True, False])
 def test_active_append_slash_setting(append_slash, rf):
     item = NavItem(title=..., url="http://testserver/test")


### PR DESCRIPTION
Closes #169.  If the URL of a navigation item is missing the scheme or the network location we ignore it in the check.