### PR TITLE
Short-circuit in `NavGroup.get_active`

### DIFF
--- a/src/django_simple_nav/nav.py
+++ b/src/django_simple_nav/nav.py
@@ -240,12 +240,10 @@ class NavGroup(NavItem):
 
     @override
     def get_active(self, request: HttpRequest) -> bool:
-        is_active = super().get_active(request)
-
+        if super().get_active(request):
+            return True
         items = self.get_items(request)
-        item_is_active = any([item.get_active(request) for item in items])
-
-        return is_active or item_is_active
+        return any(item.get_active(request) for item in items)
 
     @override
     def check_permissions(self, request: HttpRequest) -> bool:


### PR DESCRIPTION
While doing #172 I also noticed potential for a small performance improvement.

- If the superclass check succeeds we do not need to check the items because the `or` in the `return` statement would short-circuit anyway regardless whether any of the items are active or not
- Since `any` returns `True` on the first success we do not need the entire list. Using a generator saves us from evaluating the remaining `get_active` calls. If any of the items has an expensive implementation of `get_active` we save ourselves from calling it.