### PR TITLE
Update Dependabot to monthly patch Tuesday schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,18 @@
+# Dependabot schedule managed by https://github.com/westerveltco/web-dependabot-config
+# Updates: 2nd Tuesday of each month at ~9am CT
+# Schedule: https://crontab.guru/#0_14_8-14_*_2
 version: 2
 updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
-      timezone: America/Chicago
+      interval: cron
+      cronjob: 0 14 8-14 * 2
     labels:
-      - 🤖 dependabot
+      - "🤖 dependabot"
     groups:
       gha:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Update Dependabot configuration to use monthly patch Tuesday schedule
with standardized settings.