### PR TITLE
enable more ruff rule groups

### DIFF
--- a/.just/documentation.just
+++ b/.just/documentation.just
@@ -1,4 +1,4 @@
-set unstable := true
+set unstable
 
 justfile := justfile_directory() + "/.just/documentation.just"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.14
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format
 

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,5 @@
-set dotenv-load := true
-set unstable := true
+set dotenv-load
+set unstable
 
 mod docs ".just/documentation.just"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,12 +216,19 @@ quote-style = "double"
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["A", "B", "C", "D", "E", "F", "I"]
-ignore = ["E501", "E741"]  # temporary
+ignore = [
+  "E501",  # temporary
+  "E741",  # temporary
+  "PT006"  # TODO: change first arg on all parametrize calls to tuples
+]
 select = [
   "B",  # flake8-bugbear
+  "DJ",  # flake8-django
   "E",  # Pycodestyle
   "F",  # Pyflakes
   "I",  # isort
+  "PT",  # flake8-pytest-style
+  "S",  # flake8-bandit
   "UP"  # pyupgrade
 ]
 unfixable = []

--- a/src/django_simple_nav/nav.py
+++ b/src/django_simple_nav/nav.py
@@ -27,13 +27,15 @@ from ._typing import override
 
 logger = logging.getLogger(__name__)
 
-USER_ATTRIBUTE_PERMISSIONS = frozenset({
-    "is_anonymous",
-    "is_authenticated",
-    "is_active",
-    "is_staff",
-    "is_superuser",
-})
+USER_ATTRIBUTE_PERMISSIONS = frozenset(
+    {
+        "is_anonymous",
+        "is_authenticated",
+        "is_active",
+        "is_staff",
+        "is_superuser",
+    }
+)
 
 
 class NavItemContext(dict):
@@ -68,7 +70,7 @@ class NavItemContext(dict):
         if self._nav_item is None or self._request is None:
             return ""
         context = dict(self)
-        return mark_safe(
+        return mark_safe(  # noqa: S308
             render_to_string(self._nav_item.get_template_name(), context, self._request)
         )
 
@@ -173,7 +175,7 @@ class NavItem:
         return str(_build_renderable_context(self, request))
 
     def get_title(self) -> str:
-        return mark_safe(self.title)
+        return mark_safe(self.title)  # noqa: S308
 
     def get_url(self) -> str:
         url: str | None

--- a/tests/jinja2/environment.py
+++ b/tests/jinja2/environment.py
@@ -10,5 +10,5 @@ from django_simple_nav.jinja2 import django_simple_nav
 # Ensure the same template paths are valid for both Jinja2 and Django templates
 loader = FileSystemLoader("tests/jinja2/")
 
-environment = Environment(loader=loader, trim_blocks=True)
+environment = Environment(loader=loader, trim_blocks=True)  # noqa: S701
 environment.globals.update({"django_simple_nav": django_simple_nav})

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -73,8 +73,9 @@ def test_templatetag_with_template_name_on_nav_instance(req):
 
 def test_templatetag_with_no_arguments(req):
     req.user = AnonymousUser()
+    template = environment.from_string("{{ django_simple_nav() }}")
+
     with pytest.raises(TypeError):
-        template = environment.from_string("{{ django_simple_nav() }}")
         template.render({"request": req})
 
 

--- a/tests/test_navgroup.py
+++ b/tests/test_navgroup.py
@@ -183,12 +183,13 @@ def test_get_url_override():
         def get_url(self):
             url = super().get_url()
             if url == "":
-                raise ValueError
+                msg = "empty URL"
+                raise ValueError(msg)
             return url
 
     group = GetURLNavGroup(title=..., items=[...])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="empty URL"):
         group.get_url()
 
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -122,4 +122,4 @@ def test_get_template_engine_app_setting_invalid():
     with pytest.raises(ImproperlyConfigured) as exc_info:
         get_template_engine()
 
-        assert "Invalid `TEMPLATE_BACKEND` for a template engine" in exc_info
+    assert "Invalid `TEMPLATE_BACKEND` for a template engine" in str(exc_info.value)


### PR DESCRIPTION
Enables Ruff's Django, pytest-style, and Bandit rule groups.

- switches pre-commit to the current ruff-check hook
- enables DJ, PT, and S selectors
- keeps existing ignores and adds a temporary PT006 ignore for the existing parametrize style
- fixes the smaller pytest-style findings
- adds targeted noqa comments for intentional safe-string/test-environment cases