### PR TITLE
chore: enable core Ruff rule groups

### DIFF
--- a/.just/documentation.just
+++ b/.just/documentation.just
@@ -1,4 +1,4 @@
-set unstable := true
+set unstable
 
 justfile := justfile_directory() + "/.just/documentation.just"
 

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,5 @@
-set dotenv-load := true
-set unstable := true
+set dotenv-load
+set unstable
 
 mod docs ".just/documentation.just"
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -47,11 +47,8 @@ def should_skip(python: str, django: str) -> bool:
         # Django 6.0 requires Python 3.12+
         return True
 
-    if django == DJ52 and version(python) < version(PY310):
-        # Django 5.2 requires Python 3.10+
-        return True
-
-    return False
+    # Django 5.2 requires Python 3.10+
+    return django == DJ52 and version(python) < version(PY310)
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,10 +218,23 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 fixable = ["A", "B", "C", "D", "E", "F", "I"]
 ignore = ["E501", "E741"]  # temporary
 select = [
+  "A",  # flake8-builtins
   "B",  # flake8-bugbear
+  "C4",  # flake8-comprehensions
+  "DJ",  # flake8-django
+  "DTZ",  # flake8-datetimez
   "E",  # Pycodestyle
   "F",  # Pyflakes
+  "G",  # flake8-logging-format
   "I",  # isort
+  "LOG",  # flake8-logging
+  "PIE",  # flake8-pie
+  "PT",  # flake8-pytest-style
+  "RET",  # flake8-return
+  "RUF100",  # unused noqa
+  "S",  # flake8-bandit
+  "SIM",  # flake8-simplify
+  "T20",  # flake8-print
   "UP"  # pyupgrade
 ]
 unfixable = []
@@ -232,8 +245,12 @@ known-first-party = ["django_simple_nav"]
 required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.per-file-ignores]
-# Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+# Sphinx expects a `copyright` setting in conf.py.
+"docs/conf.py" = ["A001"]
+# Tests can use magic values, assertions, relative imports, and pytest's legacy string parameter lists.
+"tests/**/*" = ["PLR2004", "PT006", "S101", "TID252"]
+# Tests intentionally use Jinja2 without autoescape to exercise template behavior.
+"tests/jinja2/environment.py" = ["S701"]
 
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.

--- a/src/django_simple_nav/nav.py
+++ b/src/django_simple_nav/nav.py
@@ -27,13 +27,15 @@ from ._typing import override
 
 logger = logging.getLogger(__name__)
 
-USER_ATTRIBUTE_PERMISSIONS = frozenset({
-    "is_anonymous",
-    "is_authenticated",
-    "is_active",
-    "is_staff",
-    "is_superuser",
-})
+USER_ATTRIBUTE_PERMISSIONS = frozenset(
+    {
+        "is_anonymous",
+        "is_authenticated",
+        "is_active",
+        "is_staff",
+        "is_superuser",
+    }
+)
 
 
 class NavItemContext(dict):
@@ -68,7 +70,7 @@ class NavItemContext(dict):
         if self._nav_item is None or self._request is None:
             return ""
         context = dict(self)
-        return mark_safe(
+        return mark_safe(  # noqa: S308
             render_to_string(self._nav_item.get_template_name(), context, self._request)
         )
 
@@ -173,7 +175,7 @@ class NavItem:
         return str(_build_renderable_context(self, request))
 
     def get_title(self) -> str:
-        return mark_safe(self.title)
+        return mark_safe(self.title)  # noqa: S308
 
     def get_url(self) -> str:
         url: str | None
@@ -289,7 +291,7 @@ class NavItem:
             if getattr(user, "is_superuser", False):
                 permission_checks.append(True)
                 break
-            elif callable(perm):
+            if callable(perm):
                 has_perm = perm(request)
             elif perm in USER_ATTRIBUTE_PERMISSIONS:
                 has_perm = getattr(user, perm, False)
@@ -298,7 +300,7 @@ class NavItem:
 
             permission_checks.append(has_perm)
 
-            if not idx == len(self.permissions) - 1:
+            if idx != len(self.permissions) - 1:
                 continue
 
         return all(permission_checks)

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -73,8 +73,8 @@ def test_templatetag_with_template_name_on_nav_instance(req):
 
 def test_templatetag_with_no_arguments(req):
     req.user = AnonymousUser()
+    template = environment.from_string("{{ django_simple_nav() }}")
     with pytest.raises(TypeError):
-        template = environment.from_string("{{ django_simple_nav() }}")
         template.render({"request": req})
 
 

--- a/tests/test_navgroup.py
+++ b/tests/test_navgroup.py
@@ -188,7 +188,7 @@ def test_get_url_override():
 
     group = GetURLNavGroup(title=..., items=[...])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="^$"):
         group.get_url()
 
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -58,9 +58,8 @@ def test_get_template_engine_no_engine():
     ],
 )
 def test_get_template_engine_multiple(templates, expected, caplog):
-    with override_settings(TEMPLATES=templates):
-        with caplog.at_level("WARNING"):
-            engine = get_template_engine()
+    with override_settings(TEMPLATES=templates), caplog.at_level("WARNING"):
+        engine = get_template_engine()
 
     assert engine.name == expected
     assert "Multiple `BACKEND` defined for a template engine." in caplog.text
@@ -122,4 +121,4 @@ def test_get_template_engine_app_setting_invalid():
     with pytest.raises(ImproperlyConfigured) as exc_info:
         get_template_engine()
 
-        assert "Invalid `TEMPLATE_BACKEND` for a template engine" in exc_info
+    assert "Invalid `TEMPLATE_BACKEND` for a template engine" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- Enable the shared core Ruff rule groups for `django-simple-nav`.
- Apply trivial fixes and targeted ignores so Ruff passes.

## Validation
- `just lint`

## Why these rules

The goal here is a boring, broadly useful Ruff baseline for Python/Django projects: catch correctness issues, framework-specific mistakes, test quality problems, security footguns, naive datetime usage, logging problems, and low-noise readability issues without enabling higher-churn families like `ANN`, `ARG`, full `PL`, full `RUF`, or `TRY`.

| Ruff code | What it is | Why it is a good default |
|---|---|---|
| `E` | `pycodestyle` errors | A small baseline for Python style errors that are not handled purely by formatting. These are familiar, low-surprise checks. |
| `F` | `Pyflakes` | High-signal correctness checks: undefined names, unused imports, duplicate definitions, invalid string formatting, and other issues that are often real bugs. |
| `I` | `isort` import sorting | Keeps import blocks deterministic and easy to review. This removes one common source of mechanical diff noise. |
| `B` | `flake8-bugbear` | Catches practical Python footguns: mutable defaults, problematic exception handling, loop-binding mistakes, useless expressions, and similar bug-prone patterns. |
| `UP` | `pyupgrade` | Keeps code aligned with the repository's target Python version and removes obsolete compatibility patterns. This helps the codebase stay consistent as Python versions move forward. |
| `DJ` | `flake8-django` | Adds Django-specific checks for models, forms, and framework conventions. These catch issues general Python linters cannot see, such as risky `ModelForm` exposure or model definition problems. |
| `PT` | `flake8-pytest-style` | Keeps tests idiomatic and consistent: parametrization shape, `pytest.raises` usage, fixture style, and pytest-vs-unittest assertion patterns. |
| `S` | Bandit security rules | Provides a baseline for common security-sensitive mistakes: suspicious `mark_safe`, hardcoded secrets, weak randomness, subprocess hazards, unsafe temp files, and raw SQL-ish patterns. It is not a full security review, but it is a useful default safety net. |
| `DTZ` | timezone-aware datetime rules | Especially useful in Django apps, where naive datetimes can become production bugs. These rules encourage explicit timezone-aware datetime usage. |
| `G` | `flake8-logging-format` | Enforces lazy logging formatting instead of f-strings, `.format()`, or `%` interpolation before the log call. This preserves normal logging behavior and avoids doing formatting work when the message is not emitted. |
| `LOG` | logging convention rules | Catches broader logging issues such as root logger usage, weak exception logging, redundant exception text, and logger setup problems. Good logging conventions improve diagnostics without changing application behavior. |
| `T20` | `print()` checks | In application and package code, stdout is usually the wrong interface for diagnostics. This nudges code toward logging, explicit CLI output, test assertions, or deletion. |
| `A` | builtin shadowing | Flags names like `id`, `type`, `list`, `filter`, and `input`. Avoiding builtin shadowing keeps code clearer and avoids subtle surprises when those builtins are needed later. |
| `C4` | comprehension cleanup | Catches redundant or inefficient comprehension patterns, such as unnecessary intermediate lists. These are usually straightforward readability/performance improvements. |
| `PIE` | `flake8-pie` small correctness/cleanup rules | A collection of low-noise checks for minor correctness and maintainability issues, such as unnecessary kwargs expansion, duplicate enum values, and repeated `startswith`/`endswith` patterns. |
| `RET` | return-path cleanup | Simplifies control flow by catching unnecessary `else` after `return`, redundant assignment-before-return, and implicit return patterns. The result is easier-to-scan functions. |
| `SIM` | `flake8-simplify` | Finds simpler equivalent forms for common conditionals and expressions, such as `x in dict.keys()`, collapsible `if` statements, or redundant boolean logic. Useful when the simplification is obvious and low risk. |
| `RUF100` | unused `noqa` comments | Keeps suppressions honest. Dead `noqa` comments make it harder to tell which suppressions are still intentional and can hide future issues. |
