### PR TITLE
Add Django 6.1, drop Django 4.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: 1.29.1
     hooks:
       - id: django-upgrade
-        args: [--target-version, "4.2"]
+        args: [--target-version, "5.2"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,17 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Added
+
+- Support for Django 6.1.
+
 ### Changed
 
 - The `django_simple_nav` template tag now accepts `template_name` as a keyword argument (e.g. `template_name="footer_nav.html"`). Positional usage is still supported.
+
+### Removed
+
+- Dropped support for Django 4.2.
 
 ## [0.15.0]
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 <!-- docs-intro-start -->
 [![PyPI](https://img.shields.io/pypi/v/django-simple-nav)](https://pypi.org/project/django-simple-nav/)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/django-simple-nav)
-![Django Version](https://img.shields.io/badge/django-4.2%20%7C%205.2%20%7C%206.0-%2344B78B?labelColor=%23092E20)
+![Django Version](https://img.shields.io/badge/django-5.2%20%7C%206.0%20%7C%206.1-%2344B78B?labelColor=%23092E20)
 <!-- https://shields.io/badges -->
-<!-- django-4.2 | 5.2 | 6.0-#44B78B -->
+<!-- django-5.2 | 6.0 | 6.1-#44B78B -->
 <!-- labelColor=%23092E20 -->
 Define your navigation in Python, render it in templates. `django-simple-nav` handles URL resolution, active state detection, and permission filtering so your nav stays in sync with your project.
 <!-- docs-intro-end -->
@@ -14,7 +14,7 @@ Define your navigation in Python, render it in templates. `django-simple-nav` ha
 ## Requirements
 
 - Python 3.10, 3.11, 3.12, 3.13, 3.14
-- Django 4.2, 5.2, 6.0
+- Django 5.2, 6.0, 6.1
 <!-- docs-requirements-end -->
 
 <!-- docs-installation-start -->

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,12 +18,12 @@ PY_VERSIONS = [PY310, PY311, PY312, PY313, PY314]
 PY_DEFAULT = PY_VERSIONS[0]
 PY_LATEST = PY_VERSIONS[-1]
 
-DJ42 = "4.2"
 DJ52 = "5.2"
 DJ60 = "6.0"
+DJ61 = "6.1"
 DJMAIN = "main"
 DJMAIN_MIN_PY = PY312
-DJ_VERSIONS = [DJ42, DJ52, DJ60, DJMAIN]
+DJ_VERSIONS = [DJ52, DJ60, DJ61, DJMAIN]
 DJ_LTS = [
     version for version in DJ_VERSIONS if version.endswith(".2") and version != DJMAIN
 ]
@@ -43,12 +43,8 @@ def should_skip(python: str, django: str) -> bool:
         # Django main requires Python 3.12+
         return True
 
-    if django == DJ60 and version(python) < version(PY312):
-        # Django 6.0 requires Python 3.12+
-        return True
-
-    # Django 5.2 requires Python 3.10+
-    return django == DJ52 and version(python) < version(PY310)
+    # Django 6.0+ requires Python 3.12+
+    return django in (DJ60, DJ61) and version(python) < version(PY312)
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,11 +41,9 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Framework :: Django",
-  "Framework :: Django :: 4.2",
-  "Framework :: Django :: 5.0",
-  "Framework :: Django :: 5.1",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
+  "Framework :: Django :: 6.1",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
@@ -59,7 +57,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython"
 ]
 dependencies = [
-  "django>=4.2"
+  "django>=5.2"
 ]
 description = "A simple, flexible, and extensible navigation menu for Django."
 keywords = []


### PR DESCRIPTION
Raises the Django floor to 5.2 and adds Django 6.1 to the matrix. Python support is unchanged — `requires-python` is already `>=3.10` and the matrix already covers 3.10–3.14.

## Supported versions after this PR

- **Python** 3.10, 3.11, 3.12, 3.13, 3.14
- **Django** 5.2, 6.0, 6.1

| Django | Python |
|---|---|
| 5.2 | 3.10 – 3.14 |
| 6.0 | 3.12 – 3.14 |
| 6.1 | 3.12 – 3.14 |
| main | 3.12 – 3.14 |

With 4.2 gone, `should_skip` collapses to a single rule — Django 6.0+ needs Python 3.12+ — since 5.2 covers the whole Python range.

## Breaking

`django>=4.2` → `django>=5.2` drops the 4.2 LTS. Entirely your call whether that fits this project's support policy; happy to close this if you would rather keep 4.2 for now.

Context: this came out of a sweep across the Westervelt packages moving everything to Python 3.10–3.14 and Django 5.2/6.0/6.1. `django-twc-ui` depends on `django-simple-nav>=0.7.0` and is raising its own floor to 5.2 in [westerveltco/django-twc-ui#300](https://github.com/westerveltco/django-twc-ui/pull/300), so the two would stay consistent — but nothing there breaks if this stays on 4.2, since a lower floor does not restrict consumers.

## Also updated

- `.pre-commit-config.yaml` — `django-upgrade --target-version` was still `4.2`, now `5.2`
- `README.md` Requirements and the Django badge; `docs/index.md` pulls that block via `start-after`/`end-before`, so it follows automatically
- `CHANGELOG.md` — `### Added` for 6.1, `### Removed` for 4.2

## Verification

- `tests(python='3.10', django='5.2')` — 256 passed
- `tests(python='3.12', django='6.0')` — 256 passed
- `tests(python='3.14', django='6.1')` — 256 passed

No source changes were needed, and there are no Django-version compatibility shims in the package to clean up.